### PR TITLE
main: fix incorrect time handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,12 +23,18 @@ type Team struct {
 }
 
 type Game struct {
-	Team1    Team
-	Team2    Team
+	Team1 Team
+	Team2 Team
+
+	startTime time.Time
+	duration  time.Duration
+
+	// XXX: remove from api?
 	TimeLeft time.Duration
 	TimeStr  string
-	Half     int
-	Running  bool
+
+	Half    int
+	Running bool
 }
 
 type StateChange struct {
@@ -54,7 +60,9 @@ func init() {
 }
 
 func tickOnce() {
-	currentGame.TimeLeft -= time.Duration(100 * time.Millisecond)
+	gameEndTime := currentGame.startTime.Add(currentGame.duration)
+	timeLeft := gameEndTime.Sub(time.Now())
+	currentGame.TimeLeft = timeLeft
 	if currentGame.TimeLeft <= 0 {
 		currentGame.Running = false
 	}
@@ -80,6 +88,8 @@ func formatTime() {
 func tick() {
 	for {
 		if !currentGame.Running {
+			currentGame.duration = currentGame.TimeLeft
+			currentGame.startTime = time.Now()
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
@@ -132,7 +142,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newGame.TimeLeft = time.Duration(newGame.TimeLeft)
+	newGame.duration = time.Duration(newGame.TimeLeft)
 	currentGame = newGame
 	formatTime()
 

--- a/main_test.go
+++ b/main_test.go
@@ -102,10 +102,15 @@ func (g *GamescoreTestSuite) TestChangeState(c *C) {
 
 func (g *GamescoreTestSuite) TestTick(c *C) {
 	currentGame = *testGame
+	currentGame.startTime = time.Now()
+	currentGame.duration = 120 * time.Second
 
 	tickOnce()
-	c.Assert(currentGame.TimeLeft, Equals, testGame.TimeLeft-time.Duration(100*time.Millisecond))
 	c.Assert(currentGame.TimeStr, Equals, "01:59")
+	for i := 0; i < 11; i++ {
+		tickOnce()
+	}
+	c.Assert(currentGame.TimeStr, Equals, "01:58")
 }
 
 func (g *GamescoreTestSuite) TestFormatTime(c *C) {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: gamescore
-version: 1.0.7
+version: 1.0.8
 summary: Gamescore is a system to display and edit the score of a sports game.
 description: |
   Display/edit the score of a game like hockey, soccer etc.


### PR DESCRIPTION
The time was measured by simply using 100ms ticker ticks that got
added. However this is not precise (at all). Christian measured
that the times are almost 10% off. This commit fixes this.